### PR TITLE
FIX: Qt/GUI masternode wizard

### DIFF
--- a/src/qt/dogecash/masternodewizarddialog.cpp
+++ b/src/qt/dogecash/masternodewizarddialog.cpp
@@ -14,6 +14,8 @@
 #include "qt/dogecash/guitransactionsutils.h"
 #include "qt/dogecash/qtutils.h"
 
+#include "wallet/wallet.h"
+
 #include <QFile>
 #include <QIntValidator>
 #include <QHostAddress>
@@ -162,7 +164,7 @@ bool MasterNodeWizardDialog::createMN()
     1) generate the mn key.
     2) create the mn address.
     3) if there is a valid (unlocked) collateral utxo, use it
-    4) otherwise create a receiving address and send a tx with 10k to it.
+    4) otherwise create a receiving address and send a tx with 15k to it.
     5) get the collateral output.
     6) use those values on the masternode.conf
      */
@@ -214,7 +216,7 @@ bool MasterNodeWizardDialog::createMN()
         SendCoinsRecipient sendCoinsRecipient(
                 QString::fromStdString(dest.ToString()),
                 QString::fromStdString(alias),
-                CAmount(5000) * COIN,
+                CAmount(GetMNCollateral(chainActive.Height())) * COIN,
                 "");
 
         // Send the 10 tx to one of your address

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -975,7 +975,9 @@ bool WalletModel::getMNCollateralCandidate(COutPoint& outPoint)
 {
     CWallet::AvailableCoinsFilter coinsFilter;
     coinsFilter.fIncludeDelegated = false;
-    coinsFilter.nCoinType = ONLY_5000;
+    coinsFilter.nMaxOutValue = GetMNCollateral(chainActive.Height());
+    coinsFilter.nMinOutValue = coinsFilter.nMaxOutValue;
+    coinsFilter.fIncludeLocked = true;
     std::vector<COutput> vCoins;
     wallet->AvailableCoins(&vCoins, nullptr, coinsFilter);
     for (const COutput& out : vCoins) {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -496,7 +496,9 @@ UniValue getmasternodeoutputs (const JSONRPCRequest& request)
     // Find possible candidates
     CWallet::AvailableCoinsFilter coinsFilter;
     coinsFilter.fIncludeDelegated = false;
-    coinsFilter.nCoinType = ONLY_5000;
+    coinsFilter.nMaxOutValue = GetMNCollateral(chainActive.Height());
+    coinsFilter.nMinOutValue = coinsFilter.nMaxOutValue;
+    coinsFilter.fIncludeLocked = true;
     std::vector<COutput> possibleCoins;
     pwalletMain->AvailableCoins(&possibleCoins, nullptr, coinsFilter);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -121,7 +121,7 @@ enum WalletFeature {
 
 enum AvailableCoinsType {
     ALL_COINS = 1,
-    ONLY_5000 = 5,                                 // find masternode outputs including locked ones (use with caution)
+    ONLY_5000 = 5,                                  // ** DEPRECATED: find masternode outputs including locked ones (use with caution)
     STAKEABLE_COINS = 6                             // UTXO's that are valid for staking
 };
 
@@ -802,6 +802,9 @@ public:
         bool fIncludeLocked{false};
         // Select outputs with value <= nMaxOutValue
         CAmount nMaxOutValue{0};
+        CAmount nMinOutValue{0}; // 0 means not active
+        CAmount nMinimumSumAmount{0}; // 0 means not active
+        unsigned int nMaximumCount{0}; // 0 means not active
     };
 
     //! >> Available coins (generic)


### PR DESCRIPTION
This PR aims to fix the Qt/GUI masternode creator wizard by checking for (or sending) a TX with proper amount of coins.

It also fixes the `getmasternodeoutputs` RPC command and obsoletes the usage of `ONLY_5000` CoinType filtering constant in favor of more modern min+max approach and `GetMNCollateral()` method.

NOTE: This PR should be tested!